### PR TITLE
feat: support regional endpoints in STT

### DIFF
--- a/src/rest-api.js
+++ b/src/rest-api.js
@@ -1,10 +1,10 @@
 const base64 = require('base64-js');
 
-async function speechToText(audioBuffer, sampleRate, languageCode, apiKey) {
+async function speechToText(audioBuffer, sampleRate, languageCode, apiKey, regionalEndpoint = 'https://speech.googleapis.com') {
   // Reference: https://cloud.google.com/speech-to-text/docs/reference/rest/v1/speech/recognize
 
   const response = await fetch(
-    `https://speech.googleapis.com/v1/speech:recognize?key=${apiKey}`,
+    `${regionalEndpoint}/v1/speech:recognize?key=${apiKey}`,
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Google supports regional endpoints for STT. As voice data is considered sensitive personal data (GDPR), as it is biometric data, it is best to let users send their data to servers in the EU region: https://cloud.google.com/speech-to-text/docs/endpoints

The default is the standard endpoint without any regional prefix, which is the same as the US endpoint.